### PR TITLE
Move ssh commands to runner scripts

### DIFF
--- a/scripts/bundler/releases.sh
+++ b/scripts/bundler/releases.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+mkdir -p $HOME/logs/bundler/releases
+exec &>> $HOME/logs/bundler/releases/run.log
+
+echo
+echo
+echo
+echo
+echo --------------$(date)
+
+BUNDLER_VERSION=$1
+API_NAME=$2
+API_PASSWORD=$3
+PATTERNS=$4
+
+set -x
+
+docker pull rubybench/bundler_releases
+
+docker run --rm \
+  -e "BUNDLER_VERSION=$BUNDLER_VERSION" \
+  -e "API_NAME=$API_NAME" \
+  -e "API_PASSWORD=$API_PASSWORD" \
+  -e "INCLUDE_PATTERNS=$PATTERNS" \
+  rubybench/bundler_releases

--- a/scripts/rails/master.sh
+++ b/scripts/rails/master.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+mkdir -p $HOME/logs/rails/master
+exec &>> $HOME/logs/rails/master/run.log
+
+echo
+echo
+echo
+echo
+echo --------------$(date)
+
+COMMIT_HASH = $1
+API_NAME = $2
+API_PASSWORD = $3
+PATTERNS = $4
+
+set -x
+
+docker pull rubybench/rails_trunk
+
+docker run --name postgres -d postgres:9.3.5
+docker run --name mysql -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -d mysql:5.6.24
+docker run --name redis -d redis:2.8.19
+
+docker run --rm \
+  --link postgres:postgres \
+  --link mysql:mysql \
+  --link redis:redis \
+  -e "RAILS_COMMIT_HASH=$COMMIT_HASH" \
+  -e "API_NAME=$API_NAME" \
+  -e "API_PASSWORD=$API_PASSWORD" \
+  -e "MYSQL2_PREPARED_STATEMENTS=1" \
+  -e "INCLUDE_PATTERNS=$PATTERNS" \
+  rubybench/rails_trunk
+
+docker stop postgres mysql redis
+docker rm -v postgres mysql redis

--- a/scripts/rails/releases.sh
+++ b/scripts/rails/releases.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+mkdir -p $HOME/logs/rails/releases
+exec &>> $HOME/logs/rails/releases/run.log
+
+echo
+echo
+echo
+echo
+echo "-------------- $(date)"
+
+RAILS_VERSION=$1
+API_NAME=$2
+API_PASSWORD=$3
+CUSTOM_ENV=$4
+PATTERNS=$5
+
+set -x
+
+docker pull rubybench/rails_releases
+
+docker run --name postgres -d postgres:9.3.5
+docker run --name mysql -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -d mysql:5.6.24
+docker run --name redis -d redis:2.8.19
+
+docker run --rm \
+  --link postgres:postgres \
+  --link mysql:mysql \
+  --link redis:redis \
+  -e "RAILS_VERSION=$RAILS_VERSION" \
+  -e "API_NAME=$API_NAME" \
+  -e "API_PASSWORD=$API_PASSWORD" \
+  $CUSTOM_ENV \
+  -e "INCLUDE_PATTERNS=$PATTERNS" \
+  rubybench/rails_releases
+
+docker stop postgres mysql redis
+docker rm -v postgres mysql redis

--- a/scripts/ruby/releases.sh
+++ b/scripts/ruby/releases.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+mkdir -p $HOME/logs/ruby/releases
+exec &>> $HOME/logs/ruby/releases/run.log
+
+echo
+echo
+echo
+echo
+echo --------------$(date)
+
+RUBY_BENCHMARKS=$1
+RUBY_MEMORY_BENCHMARKS=$2
+OPTCARROT_BENCHMARK=$3
+LIQUID_BENCHMARK=$4
+RUBY_VERSION=$5
+API_NAME=$6
+API_PASSWORD=$7
+PATTERNS=$8
+
+set -x
+
+docker pull rubybench/ruby_releases
+
+docker run --rm \
+  -e "RUBY_BENCHMARKS=$RUBY_BENCHMARKS" \
+  -e "RUBY_MEMORY_BENCHMARKS=$RUBY_MEMORY_BENCHMARKS" \
+  -e "OPTCARROT_BENCHMARK=$OPTCARROT_BENCHMARK" \
+  -e "LIQUID_BENCHMARK=$LIQUID_BENCHMARK" \
+  -e "RUBY_VERSION=$RUBY_VERSION" \
+  -e "API_NAME=$API_NAME" \
+  -e "API_PASSWORD=$API_PASSWORD" \
+  -e "INCLUDE_PATTERNS=$PATTERNS" \
+  rubybench/ruby_releases

--- a/scripts/ruby/trunk.sh
+++ b/scripts/ruby/trunk.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+mkdir -p $HOME/logs/ruby/trunk
+exec &>> $HOME/logs/ruby/trunk/run.log
+
+echo
+echo
+echo
+echo
+echo --------------$(date)
+
+RUBY_BENCHMARKS=$1
+RUBY_MEMORY_BENCHMARKS=$2
+OPTCARROT_BENCHMARK=$3
+LIQUID_BENCHMARK=$4
+RUBY_COMMIT_HASH=$5
+API_NAME=$6
+API_PASSWORD=$7
+PATTERNS=$8
+
+set -x
+
+docker pull rubybench/ruby_trunk
+
+docker run --rm \
+  -e "RUBY_BENCHMARKS=$RUBY_BENCHMARKS" \
+  -e "RUBY_MEMORY_BENCHMARKS=$RUBY_MEMORY_BENCHMARKS" \
+  -e "OPTCARROT_BENCHMARK=$OPTCARROT_BENCHMARK" \
+  -e "LIQUID_BENCHMARK=$LIQUID_BENCHMARK" \
+  -e "RUBY_COMMIT_HASH=$RUBY_COMMIT_HASH" \
+  -e "API_NAME=$API_NAME" \
+  -e "API_PASSWORD=$API_PASSWORD" \
+  -e "INCLUDE_PATTERNS=$PATTERNS" \
+  rubybench/ruby_trunk

--- a/scripts/sequel/master.sh
+++ b/scripts/sequel/master.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+mkdir -p $HOME/logs/sequel/master
+exec &>> $HOME/logs/sequel/master/run.log
+
+echo "-----------$(date)"
+
+SEQUEL_COMMIT_HASH=$1
+API_NAME=$2
+API_PASSWORD=$3
+PATTERNS=$4
+
+set -x
+
+docker pull rubybench/sequel_trunk
+
+docker run --name postgres -d postgres:9.3.5
+docker run --name mysql -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -d mysql:5.6.24
+docker run --name redis -d redis:2.8.19
+
+docker run --rm \
+  --link postgres:postgres \
+  --link mysql:mysql \
+  --link redis:redis \
+  -e "SEQUEL_COMMIT_HASH=$SEQUEL_COMMIT_HASH" \
+  -e "API_NAME=$API_NAME" \
+  -e "API_PASSWORD=$API_PASSWORD" \
+  -e "MYSQL2_PREPARED_STATEMENTS=1" \
+  -e "INCLUDE_PATTERNS=$PATTERNS" \
+  rubybench/sequel_trunk
+
+docker stop postgres mysql redis
+docker rm -v postgres mysql redis

--- a/scripts/sequel/releases.sh
+++ b/scripts/sequel/releases.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+mkdir -p $HOME/logs/sequel/releases
+exec &>> $HOME/logs/sequel/releases/run.log
+
+echo "-----------$(date)"
+
+SEQUEL_VERSION=$1
+API_NAME=$2
+API_PASSWORD=$3
+PATTERNS=$4
+
+set -x
+
+docker pull rubybench/sequel_releases
+
+docker run --name postgres -d postgres:9.3.5
+docker run --name mysql -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -d mysql:5.6.24
+docker run --name redis -d redis:2.8.19
+
+docker run --rm \
+  --link postgres:postgres \
+  --link mysql:mysql \
+  --link redis:redis \
+  -e "SEQUEL_VERSION=$SEQUEL_VERSION" \
+  -e "API_NAME=$API_NAME" \
+  -e "API_PASSWORD=$API_PASSWORD" \
+  -e "MYSQL2_PREPARED_STATEMENTS=1" \
+  -e "INCLUDE_PATTERNS=$PATTERNS" \
+  rubybench/sequel_releases
+
+docker stop postgres mysql redis
+docker rm -v postgres mysql redis


### PR DESCRIPTION
We are currently executing commands for running benchmarks one by one from [RemoteServerJob](https://github.com/ruby-bench/ruby-bench-web/blob/master/app/jobs/remote_server_job.rb). I moved those to scripts which would be placed on server and called from [RemoteServerJob](https://github.com/ruby-bench/ruby-bench-web/blob/master/app/jobs/remote_server_job.rb).

Primarily I did this because I want to log if any error from running those commands. If you take a look at one of scripts you'll notice output redirected with `exec &>> file/to/log`. It would help us with debugging errors. I did this after trying to find out why rails benchmarks aren't run.