### PR TITLE
Update sequel_trunk Dockerfile

### DIFF
--- a/sequel/sequel_trunk/sequel_benchmarks/Dockerfile
+++ b/sequel/sequel_trunk/sequel_benchmarks/Dockerfile
@@ -1,8 +1,8 @@
-FROM rubybench/ruby:0.4
+FROM rubybench/ruby:0.5
 MAINTAINER Alan Guo Xiang Tan "https://twitter.com/tgx_world"
 
 RUN apt-get update
-RUN apt-get install -y libncurses5-dev libmysqlclient-dev postgresql mysql-server-5.6
+RUN apt-get install -y libncurses5-dev libmysqlclient-dev postgresql-client mysql-client
 
 RUN git clone --verbose --branch master --single-branch https://github.com/ruby-bench/ruby-bench-suite.git
 RUN git clone --verbose --branch master --single-branch https://github.com/jeremyevans/sequel.git


### PR DESCRIPTION
Sequel suite has to be run on same ruby version as Rails suite, in order to make fair comparisons:exclamation: 