### PR TITLE
Remove volumes when removing containers

### DIFF
--- a/scripts/pg/master.sh
+++ b/scripts/pg/master.sh
@@ -26,4 +26,4 @@ docker-compose run \
   pg_master \
   /bin/bash -l -c "./runner"
 
-docker-compose down
+docker-compose down -v

--- a/scripts/rails/master.sh
+++ b/scripts/rails/master.sh
@@ -27,4 +27,4 @@ docker-compose run \
   rails_master \
   /bin/bash -l -c "./runner"
 
-docker-compose down
+docker-compose down -v

--- a/scripts/sequel/master.sh
+++ b/scripts/sequel/master.sh
@@ -27,4 +27,4 @@ docker-compose run \
   sequel_master \
   /bin/bash -l -c "./runner"
 
-docker-compose down
+docker-compose down -v


### PR DESCRIPTION
`docker-compose down` was leaving dangling volumes. This is fixed with `-v` argument.