### PR TITLE
Install benchmark_driver for ruby_benchmarks

### DIFF
--- a/ruby/ruby_releases/ruby_benchmarks/Dockerfile
+++ b/ruby/ruby_releases/ruby_benchmarks/Dockerfile
@@ -1,6 +1,7 @@
 FROM rubybench/ruby_releases_base:20180410.1
 
 RUN git clone --verbose --branch master --single-branch https://github.com/ruby-bench/ruby-bench-suite.git
+RUN gem install benchmark_driver -v 0.12.0 && gem install benchmark_driver-output-rubybench -v 0.2.0
 
 ADD runner runner
 RUN chmod 755 runner

--- a/ruby/ruby_trunk/ruby_benchmarks/Dockerfile
+++ b/ruby/ruby_trunk/ruby_benchmarks/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Guo Xiang "tgx_world@hotmail.com"
 
 RUN git clone --verbose --branch trunk --single-branch https://github.com/ruby/ruby.git
 RUN git clone --verbose --branch master --single-branch https://github.com/ruby-bench/ruby-bench-suite.git
+RUN gem install benchmark_driver -v 0.12.0 && gem install benchmark_driver-output-rubybench -v 0.2.0
 
 ADD runner runner
 ADD config.sub /ruby/tool/config.sub


### PR DESCRIPTION
To start using benchmark_driver.gem for Ruby benchmarks on RubyBench, I want to install it and its plugin for RubyBench to the ruby_benchmarks containers.