### PR TITLE
Fix: Add 2.5.5

### DIFF
--- a/ruby/ruby_releases/ruby_releases_base/Dockerfile
+++ b/ruby/ruby_releases/ruby_releases_base/Dockerfile
@@ -34,6 +34,7 @@ RUN /bin/bash -l -c "rbenv install 2.5.0"
 RUN /bin/bash -l -c "rbenv install 2.5.1"
 RUN /bin/bash -l -c "rbenv install 2.5.2"
 RUN /bin/bash -l -c "rbenv install 2.5.3"
+RUN /bin/bash -l -c "rbenv install 2.5.5"
 
 RUN /bin/bash -l -c "rbenv install 2.6.0"
 RUN /bin/bash -l -c "rbenv install 2.6.1"


### PR DESCRIPTION
The latest 2.5 version is 2.5.5. 
That should be added to the list.