### PR TITLE
Use ruby.git master instead of trunk

### DIFF
--- a/ruby/ruby_trunk/discourse_benchmarks/Dockerfile
+++ b/ruby/ruby_trunk/discourse_benchmarks/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y wget && \
       tzdata 
 
 RUN git clone --branch stable --single-branch --verbose https://github.com/discourse/discourse.git
-RUN git clone --verbose --branch trunk --single-branch https://github.com/ruby/ruby.git
+RUN git clone --verbose --branch master --single-branch https://github.com/ruby/ruby.git
 RUN git clone --branch master --single-branch https://github.com/ruby-bench/ruby-bench-suite.git
 
 # Discourse configuration files

--- a/ruby/ruby_trunk/ruby_benchmarks/Dockerfile
+++ b/ruby/ruby_trunk/ruby_benchmarks/Dockerfile
@@ -1,7 +1,7 @@
 FROM rubybench/ruby:0.3
 MAINTAINER Guo Xiang
 
-RUN git clone --verbose --branch trunk --single-branch https://github.com/ruby/ruby.git
+RUN git clone --verbose --branch master --single-branch https://github.com/ruby/ruby.git
 RUN git clone --verbose --branch master --single-branch https://github.com/ruby-bench/ruby-bench-suite.git
 
 ADD runner runner

--- a/ruby/ruby_trunk/ruby_benchmarks/per_commit_image/Dockerfile
+++ b/ruby/ruby_trunk/ruby_benchmarks/per_commit_image/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get install time
 ARG RUBY_COMMIT_HASH
 ENV RUBY_COMMIT_HASH=$RUBY_COMMIT_HASH
 
-RUN git clone --verbose --branch trunk --single-branch https://github.com/ruby/ruby.git
+RUN git clone --verbose --branch master --single-branch https://github.com/ruby/ruby.git
 
 ADD config.sub /ruby/tool/config.sub
 ADD config.guess /ruby/tool/config.guess


### PR DESCRIPTION
ruby.git's trunk branch will be deleted on Jan 1st. Let's use master branch instead.