### PR TITLE
Run discourse benchmarks in privileged mode and pin facter to v4.0.17

### DIFF
--- a/ruby/ruby_releases/discourse_benchmarks/docker-compose.yml
+++ b/ruby/ruby_releases/discourse_benchmarks/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     networks:
       - redis-net
   discourse_ruby_releases:
+    privileged: true
     build: .
     networks:
       - redis-net

--- a/ruby/ruby_releases/discourse_benchmarks/runner
+++ b/ruby/ruby_releases/discourse_benchmarks/runner
@@ -19,7 +19,7 @@ echo "RUBY_VERSION=$RUBY_VERSION"
 # For faster Bundle install
 echo "gem: --no-document" > ~/.gemrc
 gem install bundler -v 2.1.1
-gem install facter
+gem install facter -v 4.0.17
 gem install CFPropertyList
 
 if [[ ! $(psql -h postgres -U postgres -tc \

--- a/ruby/ruby_trunk/discourse_benchmarks/docker-compose.yml
+++ b/ruby/ruby_trunk/discourse_benchmarks/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     networks:
       - redis-net
   discourse_ruby_trunk:
+    privileged: true
     build: .
     networks:
       - redis-net

--- a/ruby/ruby_trunk/discourse_benchmarks/runner
+++ b/ruby/ruby_trunk/discourse_benchmarks/runner
@@ -29,7 +29,7 @@ rbenv global master
 # For faster Bundle install
 echo "gem: --no-document" > ~/.gemrc
 gem install bundler -v 2.1.1
-gem install facter
+gem install facter -v 4.0.17
 gem install CFPropertyList
 
 if [[ ! $(psql -h postgres -U postgres -tc \


### PR DESCRIPTION
I ran into a very bizarre problem while I was trying to fix the discourse benchmark. The discourse benchmark script spins up a local discourse instance using puma inside the container and use the instance to perform the benchmarks, and once the benchmarks are finished the script then tries to collect `pss` and `rss` memory metrics of the puma process by reading `/proc/<pid>/smaps`:

https://github.com/discourse/discourse/blob/ec2f3169ff43a440250bc54f7c6c43d64fcc8263/script/memstats.rb#L103-L123

This is where things get interesting: When I fire up a container **locally** and run the benchmarks in it, the benchmark script can read the `smaps` file just fine. However, when I fire up a container based off the same exact `Dockerfile` that I used locally in **our benchmark server**, the benchmark script gets a permission denied error when it tries to read the `smaps` file. The benchmark script is owned by root in the container and so is the puma process. I'm not sure if this ever worked before.

The only difference that I can see (and could cause this discrepancy) between my computer and our benchmark server is the kernel version. I run Linux kernel 4.19 and I'm using WSL2, and our benchmark server runs 3.13 (yes this too ancient we should upgrade soon). 

Running the container in privileged mode fixes the problem, but I'm not sure this is the right thing to do. Thoughts @SamSaffron?